### PR TITLE
feat(catalog): Mejorar la navegación y preservar el estado del scroll

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5014,6 +5014,16 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "license": "MIT"
     },
+    "node_modules/@types/react": {
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
+      "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/@types/react-transition-group": {
       "version": "4.4.12",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
@@ -17794,6 +17804,20 @@
       "license": "MIT",
       "dependencies": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/client/src/components/CategoryCard/CategoryCard.jsx
+++ b/client/src/components/CategoryCard/CategoryCard.jsx
@@ -1,7 +1,15 @@
 import { Card, CardActionArea, CardMedia, CardContent, Typography, Box } from '@mui/material';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 export default function CategoryCard({ category }) {
+    const navigate = useNavigate();
+
+    const handleCategoryClick = () => {
+        const categoryName = category?.name?.toLowerCase() || 'sin-categoria';
+        // Navegar a la categoría, asegurando que siempre estemos en la página 1
+        navigate(`/catalogo?category=${categoryName}&page=1`, { replace: false });
+    };
+
     return (
         <Card sx={{
             position: 'relative',
@@ -15,7 +23,7 @@ export default function CategoryCard({ category }) {
                 boxShadow: '0 6px 16px rgba(0,0,0,0.15)'
             }
         }}>
-            <CardActionArea component={Link} to={`/catalogo?category=${category?.name?.toLowerCase() || 'sin-categoria'}`}>
+            <CardActionArea onClick={handleCategoryClick}>
                 {/* Imagen de la categoría */}
                 <CardMedia
                     component="img"

--- a/client/src/components/ProductCard/ProductCard.jsx
+++ b/client/src/components/ProductCard/ProductCard.jsx
@@ -171,7 +171,7 @@ export default function ProductCard({ product: initialProduct }) {
                     image={mainImage}
                     alt={product.name}
                     className={styles.productImage}
-                    onClick={() => navigate(`/producto/${product.id}`)}
+                    onClick={() => navigate(`/producto/${product.id}`, { replace: false })}
                     onError={(e) => {
                         e.target.src = '/assets/placeholder.jpg';
                     }}


### PR DESCRIPTION
Se ha refactorizado la lógica de navegación y estado en las páginas del catálogo para solucionar problemas con el botón "atrás" del navegador y mejorar la experiencia de usuario.

PROBLEMA:
- Al navegar entre categorías o desde la vista de un producto de vuelta al catálogo, el botón "atrás" del navegador no devolvía al usuario a la vista anterior.
- La posición del scroll se perdía, obligando al usuario a desplazarse de nuevo hasta su posición anterior.

SOLUCIÓN:
- **URL como única fuente de verdad:** Se eliminó el estado local (`useState`) para la paginación. Ahora, el número de página se lee directamente de los parámetros de la URL, evitando conflictos con el historial del navegador.
- **Navegación consistente:** Se ha asegurado que todas las navegaciones dentro del catálogo creen una nueva entrada en el historial del navegador (`replace: false`), permitiendo que el botón "atrás" funcione de manera nativa y predecible.
- **Restauración del scroll:**
  - Al hacer clic en un producto, la posición vertical del scroll (`window.scrollY`) se guarda en `localStorage`.
  - Al volver a la página del catálogo, se restaura la posición del scroll y se limpia la entrada de `localStorage` para no afectar la navegación posterior.
- **Simplificación del código:** Se eliminaron los manejadores de eventos `popstate` y los `useEffect` complejos que intentaban sincronizar el estado, resultando en un código más limpio y mantenible.